### PR TITLE
Fix sonar-scanner url and updating to newest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
 FROM openjdk:8-jdk
 MAINTAINER Christian Meter <meter@cs.uni-duesseldorf.de>
 
-ENV SONAR_VERSION 3.0.3.778
+ENV SONAR_VERSION 3.3.0.1492
 ENV SONAR_ARCHIVE sonar-scanner-cli-$SONAR_VERSION-linux.zip
 
 WORKDIR /root
 
-RUN wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/$SONAR_ARCHIVE && \
+RUN wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/$SONAR_ARCHIVE && \
     unzip $SONAR_ARCHIVE && \
     rm $SONAR_ARCHIVE
 
 ENV PATH $PATH:/root/sonar-scanner-$SONAR_VERSION-linux/bin
 
 CMD sonar-scanner
-


### PR DESCRIPTION
The url to the sonar scanner has been changed. This should fix the build on dockerhub.

Maybe the new version of sonar will fix the broken CI job in our gitlab as well.